### PR TITLE
Use natural sorting to compare versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
 name = "hpkgbouncer"
 version = "0.1.0"
 dependencies = [
+ "natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-s3 0.18.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -820,6 +821,11 @@ dependencies = [
  "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "net2"
@@ -2016,6 +2022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+"checksum natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 authors = ["Alexander von Gluck IV <kallisti5@unixzen.com>"]
 
 [dependencies]
-url = "*"
+natord = "1.0.9"
 rocket = "0.4.2"
 regex = "*"
 rust-s3 = "0.18.3"
-toml = "0.4"
 serde = "*"
+toml = "0.4"
+url = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
+extern crate natord;
+
 extern crate regex;
 
 #[macro_use]

--- a/src/routecache/mod.rs
+++ b/src/routecache/mod.rs
@@ -4,12 +4,13 @@ use std::error::Error;
 use std::time::Instant;
 use std::cmp::Ordering;
 
-use url::Url;
+use natord::compare;
 
 use s3::bucket::Bucket;
 use s3::region::Region;
 use s3::credentials::Credentials;
 
+use url::Url;
 
 #[derive(Clone, Debug)]
 pub struct RouteConfig {
@@ -55,13 +56,13 @@ impl PartialEq for Route {
 
 impl PartialOrd for Route {
     fn partial_cmp(&self, other: &Route) -> Option<Ordering> {
-        Some(self.version.cmp(&other.version))
+        Some(compare(&self.version, &other.version))
     }
 }
 
 impl Ord for Route {
     fn cmp(&self, other: &Route) -> Ordering {
-        self.version.cmp(&other.version)
+        compare(&self.version, &other.version)
     }
 }
 


### PR DESCRIPTION
There is an accute issue where the 'current' link points to the wrong build. The first build has the name r1~beta2_hrev54154_7, and the most recent build has the name r1~beta2_hrev54154_47. The current sorting algorithm ranks the first build as newer than the latest.

This also futureproofs this microservice when the hrev will increase from a 5-digit number to 6-digits (e.g. hrev99999 to hrev100000)